### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ or create the pth file manually somehow. Just note that the venv file structure 
 ```
 
 
-## Dev dependecies
+## Dev dependencies
 
 Dev dependencies are listed in requirements-dev.txt, generated from requirements-dev.in with `pip-compile`
 

--- a/src/ocp_freecad_cam/fc_impl.py
+++ b/src/ocp_freecad_cam/fc_impl.py
@@ -513,7 +513,7 @@ class DrillOp(Op):
     ):
         """
         Attributes in FreeCAD but not here:
-        * RetractMode is overriden by KeepToolDown in FC code
+        * RetractMode is overridden by KeepToolDown in FC code
         * AddTipLength is not used anywhere?
         """
 


### PR DESCRIPTION
Found via `codespell -q 3 -L collet`