### PR TITLE
ci: use --ignore-installed for pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,14 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # Support for "macos-13", "macos-latest" needs a contributor!
-        release: ["latest", "1.0.1"]
+        release: ["1.0.1", "1.0.2"]
         python: [ "3.11" ]
         # exclude:
         include:
-          - python: "3.11"
-            release: "latest"
-            os: "ubuntu-latest"
-            primary: true
-
+        #   - python: "3.11"
+        #     release: "latest"
+        #     os: "ubuntu-latest"
+        #     primary: true
           - python: "3.11"
             pypattern: "py311"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,16 @@ jobs:
         run: |
           source freecad/venv/bin/activate
           python -m pip install --upgrade pip
-          pip install cadquery build123d
-          pip install -r requirements-dev.txt
+          pip install --ignore-installed cadquery build123d
+          pip install --ignore-installed -r requirements-dev.txt
 
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           .\freecad\venv\Scripts\activate
           python -m pip install --upgrade pip
-          pip install cadquery build123d
-          pip install -r requirements-dev.txt
+          pip install --ignore-installed cadquery build123d
+          pip install --ignore-installed -r requirements-dev.txt
 
       - name: Check ruff format
         if: matrix.primary


### PR DESCRIPTION
Some libraries might already be provided by the parent venv of FreeCAD causing pip to skip installing them. However because they're not installed to the main environment, python doesn't find the .so files.

It's a bit messy.